### PR TITLE
Введен список объектных файлов COMMON_OBJ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ to_obj_list = \
     done
 
 
-COMMON_OBJ = $(shell cat $(OBJ_LIST))
+COMMON_OBJ = $(shell cat $(OBJ_LIST) 2>/dev/null)
 OBJ        = $(CURDIR)/src/kernel/main.o
 OBJ       += $(COMMON_OBJ)
 

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,15 @@ to_obj_list = \
     done
 
 
+COMMON_OBJ = $(shell cat $(OBJ_LIST))
+OBJ        = $(CURDIR)/src/kernel/main.o
+OBJ       += $(COMMON_OBJ)
+
+
+
 export
-
-
  
 
-OBJ = $(shell cat $(OBJ_LIST))
 
 
 .PHONY: all

--- a/src/kernel/Makefile
+++ b/src/kernel/Makefile
@@ -1,5 +1,5 @@
 
-OBJ = main.o
+OBJ =
 
 
 


### PR DESCRIPTION
- Введен список объектных файлов COMMON_OBJ который не включает в себя main.o и который передается дочерним Makefile, который могут его использовать его для линковки со своей функцией main.
- Исправлена ошибка при работе cat, когда она читала файлег, которого нету.